### PR TITLE
Return reject windows

### DIFF
--- a/src/pyflex/config.py
+++ b/src/pyflex/config.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from future.builtins import *  # NOQA
 
-import collections
+from collections.abc import Iterable
 import numpy as np
 
 from . import PyflexError
@@ -275,7 +275,7 @@ class Config(object):
         for name in attributes:
             attr = getattr(self, name)
 
-            if isinstance(attr, collections.Iterable):
+            if isinstance(attr, Iterable):
                 if len(attr) != npts:
                     raise PyflexError(
                         "Config value '%s' does not have the same number of "

--- a/src/pyflex/window_selector.py
+++ b/src/pyflex/window_selector.py
@@ -334,7 +334,10 @@ class WindowSelector(object):
 
         self.determine_signal_and_noise_indices()
         if self.config.check_global_data_quality:
-            self.check_data_quality()
+            # Global data quality may preclude window selection
+            if not self.check_data_quality():
+                return []
+
         self.reject_windows_based_on_minimum_length()
         self.reject_on_minima_water_level()
         self.reject_on_prominence_of_central_peak()

--- a/src/pyflex/window_selector.py
+++ b/src/pyflex/window_selector.py
@@ -619,8 +619,7 @@ class WindowSelector(object):
         """
         Run the weighted interval scheduling.
         """
-        windows = schedule_weighted_intervals(self.windows)
-        self.separate_rejects(windows, "schedule")
+        self.windows = schedule_weighted_intervals(self.windows)
 
         logger.info("Weighted interval schedule optimization retained %i "
                     "windows." % len(self.windows))


### PR DESCRIPTION
This pull request adds functionality for returning rejected window information in the WindowSelector object. In the original repository, this information is discarded once suitable windows are found and remains irretrievable. With this new feature, rejected windows are categorized and returned as a Dict object with some useful information. This is useful when visualizing misfit quantification -- rejected windows can be plotted alongside chosen windows to show:
1) the total length of the waveform that is being interrogated
2) the reason for rejecting windows where they are, improving understanding of window gaps
3) how windowing parameters can be adjusted to improve window selection quality